### PR TITLE
Fix java dependency as suggested by homebrew

### DIFF
--- a/bloop.rb
+++ b/bloop.rb
@@ -8,7 +8,7 @@ class Bloop < Formula
 
   depends_on "bash-completion"
   depends_on "coursier/formulas/coursier"
-  depends_on :java => "1.8+"
+  depends_on :java => "openjdk@8+"
 
   resource "bash_completions" do
     url "https://github.com/scalacenter/bloop/releases/download/v1.4.5/bash-completions"


### PR DESCRIPTION
Fixes https://github.com/scalacenter/bloop/issues/1401

Minimal change necessary to get this to work on Big Sur with the latest homebrew.  After making this change, I was able to upgrade bloop successfully.